### PR TITLE
Update package.json and README.md for server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ FRONTEGG_API_KEY=your_api_key
 
 Replace `your_client_id` and `your_api_key` with your actual Frontegg credentials from your Frontegg account settings.
 
+## Running the Server
+
+1.  Build the project:
+    ```bash
+    npm run build
+    ```
+2.  Start the MCP server:
+    ```bash
+    npm start
+    ```
+
+This will start the server, which listens for MCP connections via standard input/output (stdio).
+
 ### How to use with Claude Desktop
 
 1.  **Locate Claude Desktop Config File**
@@ -169,16 +182,6 @@ This application acts as an MCP server (`@modelcontextprotocol/sdk/server`). It 
 The server uses `@modelcontextprotocol/sdk/server/stdio` for communication, meaning it expects MCP messages via stdin and sends responses via stdout.
 
 To interact with this server using an MCP client, configure the client to launch the `frontegg-mcp-server` executable (or run `npm start` or `node build/index.js` in the project directory).
-
-### Using with MCP Inspector
-
-You can use the MCP Inspector tool to test and debug the server:
-
-```bash
-npm run inspector
-```
-
-This will start the server and open the MCP Inspector UI, allowing you to send requests and view responses.
 
 ## Tools
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "build": "rm -rf build && tsc && node -e \"require('fs').readdirSync('build').filter(f=>f.endsWith('.js')).forEach(f=>require('fs').chmodSync('build/'+f,'755'))\"",
     "prepare": "npm run build",
     "start": "node build/index.js",
-    "start:http": "node build/http-server.js",
-    "inspector": "npx @modelcontextprotocol/inspector node build/index.js"
+    "start:http": "node build/http-server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
- Removed the inspector script from package.json.
- Added detailed instructions for building and starting the MCP server in README.md, enhancing user guidance for server setup.