### PR TITLE
Register new application tool and update API endpoint references

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ This server provides the following tools to interact with the Frontegg API:
 
 1.  `get_users_for_application`: Retrieves users assigned to a specific application.
 2.  `assign_users_to_application`: Assigns users to a specific application.
+3.  `get_applications`: Fetches Frontegg applications with optional filters.
 
 **API Tokens**
 

--- a/src/tools/applications/assign-users-to-application.tool.ts
+++ b/src/tools/applications/assign-users-to-application.tool.ts
@@ -34,7 +34,7 @@ export function registerAssignUsersToApplicationTool(server: McpServer) {
     "Assigns one or more users to a specific Frontegg application within a tenant.",
     assignUsersToApplicationSchema.shape,
     async (args: AssignUsersToApplicationArgs) => {
-      const apiUrl = buildFronteggUrl(FronteggEndpoints.APPLICATION);
+      const apiUrl = buildFronteggUrl(FronteggEndpoints.IDENTITY_APPLICATION);
 
       // Use optional headerTenantId for the header, separate from the body tenantId
       const headers = createBaseHeaders();

--- a/src/tools/applications/get-applications.tool.ts
+++ b/src/tools/applications/get-applications.tool.ts
@@ -1,0 +1,81 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  buildFronteggUrl,
+  createBaseHeaders,
+  fetchFromFrontegg,
+  formatToolResponse,
+  HttpMethods,
+  FronteggEndpoints,
+} from "../../utils/api/frontegg-api";
+
+// Zod schema based on GET /resources/applications/v1 query parameters
+const getApplicationsSchema = z
+  .object({
+    accessType: z
+      .enum(["FREE_ACCESS", "MANAGED_ACCESS"])
+      .optional()
+      .describe("Filter by access type."),
+    isDefault: z
+      .boolean()
+      .optional()
+      .describe("Filter by whether the application is the default one."),
+    isActive: z
+      .boolean()
+      .optional()
+      .describe("Filter by whether the application is active."),
+    ids: z
+      .string() // Assuming comma-separated string based on docs; adjust if it's an array
+      .optional()
+      .describe("Filter by a comma-separated list of application IDs."),
+  })
+  .strict();
+
+type GetApplicationsArgs = z.infer<typeof getApplicationsSchema>;
+
+// Function to register the get-applications tool
+export function registerGetApplicationsTool(server: McpServer) {
+  server.tool(
+    "get-applications",
+    "Fetches a list of Frontegg applications for the environment, with optional filtering.",
+    getApplicationsSchema.shape,
+    async (args: GetApplicationsArgs) => {
+      // Construct query parameters, renaming keys to match Frontegg API (_ prefix)
+      const queryParams: Record<string, string | number | boolean> = {};
+      if (args.accessType !== undefined) {
+        queryParams["_accessType"] = args.accessType;
+      }
+      if (args.isDefault !== undefined) {
+        queryParams["_isDefault"] = args.isDefault;
+      }
+      if (args.isActive !== undefined) {
+        queryParams["_isActive"] = args.isActive;
+      }
+      if (args.ids !== undefined) {
+        queryParams["ids"] = args.ids; // Note: 'ids' does not have '_' prefix in docs
+      }
+
+      const apiUrl = buildFronteggUrl(FronteggEndpoints.APPLICATION);
+      const headers = createBaseHeaders();
+
+      // Append query parameters to the URL for GET request
+      const url = new URL(apiUrl);
+      Object.entries(queryParams).forEach(([key, value]) => {
+        // Ensure value is not undefined before appending
+        if (value !== undefined) {
+          url.searchParams.append(key, String(value));
+        }
+      });
+
+      const response = await fetchFromFrontegg(
+        HttpMethods.GET,
+        url, // Pass the URL object directly
+        headers,
+        undefined, // No body for GET request
+        "get-applications" // 5 arguments now
+      );
+
+      return formatToolResponse(response);
+    }
+  );
+}

--- a/src/tools/applications/get-users-for-application.tool.ts
+++ b/src/tools/applications/get-users-for-application.tool.ts
@@ -25,7 +25,7 @@ export function registerGetUsersForApplicationTool(server: McpServer) {
     "Fetches users assigned to a specific Frontegg application.",
     getUsersForApplicationSchema.shape,
     async (args: GetUsersForApplicationArgs) => {
-      const endpointPath = `${FronteggEndpoints.APPLICATION}/${args.appId}/users`;
+      const endpointPath = `${FronteggEndpoints.IDENTITY_APPLICATION}/${args.appId}/users`;
       const apiUrl = buildFronteggUrl(endpointPath);
 
       const headers = createBaseHeaders();

--- a/src/tools/applications/index.ts
+++ b/src/tools/applications/index.ts
@@ -1,2 +1,3 @@
 export * from "./get-users-for-application.tool";
 export * from "./assign-users-to-application.tool";
+export * from "./get-applications.tool";

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -45,6 +45,7 @@ import {
 import {
   registerGetUsersForApplicationTool,
   registerAssignUsersToApplicationTool,
+  registerGetApplicationsTool,
 } from "./applications";
 
 // Import tenant tool registration functions
@@ -95,6 +96,7 @@ export function registerAllTools(server: McpServer): void {
   // Register Application Tools
   registerGetUsersForApplicationTool(server);
   registerAssignUsersToApplicationTool(server);
+  registerGetApplicationsTool(server);
 
   // // Register Tenant Tools
   registerCreateTenantTool(server);

--- a/src/utils/api/constants.ts
+++ b/src/utils/api/constants.ts
@@ -30,7 +30,8 @@ export const FronteggEndpoints = {
   CREATE_CLIENT_CREDENTIALS_TOKEN: "/identity/resources/tenants/api-tokens/v2",
   USER_ACCESS_TOKENS: "/identity/resources/users/access-tokens/v1",
   USER_API_TOKENS: "/identity/resources/users/api-tokens/v1",
-  APPLICATION: "/identity/resources/applications/v1",
+  IDENTITY_APPLICATION: "/identity/resources/applications/v1",
+  APPLICATION: "/applications/resources/applications/v1",
   TENANTS_V1: "/tenants/resources/tenants/v1",
   TENANTS_V2: "/tenants/resources/tenants/v2",
 };


### PR DESCRIPTION
- Added `registerGetApplicationsTool` to the tool registration in `src/tools/index.ts`.
- Updated API endpoint references in `assign-users-to-application.tool.ts` and `get-users-for-application.tool.ts` to use the new `IDENTITY_APPLICATION` constant.
- Exported the new tool from `src/tools/applications/index.ts` for better modularity.
- Adjusted the `FronteggEndpoints` in `constants.ts` to differentiate between identity and general application endpoints.