### PR TITLE
Add role permission management tools and update existing tools

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,7 @@ import {
   registerGetRolesTool,
   registerDeleteRoleTool,
   registerUpdateRoleTool,
+  registerSetPermissionsToRoleTool,
 } from "./roles";
 
 // Import permission tool registration functions
@@ -61,6 +62,7 @@ export function registerAllTools(server: McpServer): void {
   registerCreateRoleTool(server);
   registerDeleteRoleTool(server);
   registerUpdateRoleTool(server);
+  registerSetPermissionsToRoleTool(server);
 
   // Register Permission Tools
   registerGetPermissionsTool(server);

--- a/src/tools/permissions/delete-permission.tool.ts
+++ b/src/tools/permissions/delete-permission.tool.ts
@@ -9,10 +9,12 @@ import {
   HttpMethods,
 } from "../../utils/api/frontegg-api";
 
-// Zod schema assuming 'key' is the path parameter for deleting a permission
+// Zod schema using 'permissionId' as the path parameter
 const deletePermissionSchema = z
   .object({
-    key: z.string().describe("The unique key of the permission to delete."),
+    permissionId: z
+      .string()
+      .describe("The unique ID of the permission to delete."),
   })
   .strict();
 
@@ -21,11 +23,14 @@ type DeletePermissionArgs = z.infer<typeof deletePermissionSchema>;
 export function registerDeletePermissionTool(server: McpServer) {
   server.tool(
     "delete-permission",
-    "Deletes a specific permission in Frontegg using its key.",
+    "Deletes a specific permission in Frontegg using its ID.",
     deletePermissionSchema.shape,
     async (args: DeletePermissionArgs) => {
-      // Construct URL with the permission key
-      const apiUrl = buildFronteggUrl(FronteggEndpoints.PERMISSIONS, args.key);
+      // Construct URL with the permission ID
+      const apiUrl = buildFronteggUrl(
+        FronteggEndpoints.PERMISSIONS,
+        args.permissionId
+      );
 
       const response = await fetchFromFrontegg(
         HttpMethods.DELETE,
@@ -37,7 +42,7 @@ export function registerDeletePermissionTool(server: McpServer) {
 
       return formatToolResponse(
         response,
-        `Permission with key '${args.key}' successfully deleted.`
+        `Permission with ID '${args.permissionId}' successfully deleted.`
       );
     }
   );

--- a/src/tools/roles/index.ts
+++ b/src/tools/roles/index.ts
@@ -2,3 +2,4 @@ export * from "./get-roles.tool";
 export * from "./create-role.tool";
 export * from "./delete-role.tool";
 export * from "./update-role.tool";
+export * from "./set-permissions-to-role.tool";

--- a/src/tools/roles/set-permissions-to-role.tool.ts
+++ b/src/tools/roles/set-permissions-to-role.tool.ts
@@ -1,0 +1,66 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  buildFronteggUrl,
+  createBaseHeaders,
+  fetchFromFrontegg,
+  formatToolResponse,
+  FronteggEndpoints,
+  HttpMethods,
+} from "../../utils/api/frontegg-api";
+
+// Zod schema for the set-permissions-to-role tool arguments
+const setPermissionsToRoleSchema = z
+  .object({
+    roleId: z.string().describe("The ID of the role to set permissions for."), // Path parameter
+    fronteggTenantIdHeader: z
+      .string()
+      .optional()
+      .describe(
+        "Optional Tenant ID to associate the role with. If provided, it will be used in the request header."
+      ),
+    permissionIds: z
+      .array(z.string())
+      .describe(
+        "Array of permission IDs to attach to the role. This will override any existing permissions."
+      ),
+  })
+  .strict();
+
+type SetPermissionsToRoleArgs = z.infer<typeof setPermissionsToRoleSchema>;
+
+// Function to register the set-permissions-to-role tool
+export function registerSetPermissionsToRoleTool(server: McpServer) {
+  server.tool(
+    "set-permissions-to-role",
+    "Assigns permissions to a role. This will replace all existing permissions for the role with the new set.",
+    setPermissionsToRoleSchema.shape, // Pass the schema shape
+    async (args: SetPermissionsToRoleArgs) => {
+      const { roleId, fronteggTenantIdHeader, permissionIds } = args;
+
+      // Prepare the request body
+      const requestBody = {
+        permissionIds,
+      };
+
+      // Build API URL using centralized utility
+      const apiUrl = buildFronteggUrl(
+        `${FronteggEndpoints.ROLES}/${roleId}/permissions`
+      );
+
+      // Using centralized fetch utility
+      const response = await fetchFromFrontegg(
+        HttpMethods.PUT,
+        apiUrl,
+        createBaseHeaders({ fronteggTenantIdHeader }),
+        requestBody,
+        "set-permissions-to-role"
+      );
+
+      return formatToolResponse(
+        response,
+        `Permissions successfully assigned to role with ID '${roleId}'.`
+      );
+    }
+  );
+}

--- a/src/tools/roles/update-role.tool.ts
+++ b/src/tools/roles/update-role.tool.ts
@@ -85,7 +85,7 @@ export function registerUpdateRoleTool(server: McpServer) {
 
       // Using centralized fetch utility
       const response = await fetchFromFrontegg(
-        HttpMethods.PUT,
+        HttpMethods.PATCH,
         apiUrl,
         createBaseHeaders({ fronteggTenantIdHeader }),
         requestBody,


### PR DESCRIPTION
- Introduced `registerSetPermissionsToRoleTool` to allow assigning permissions to roles, replacing any existing permissions.
- Updated `registerAllTools` to include the new permissions tool.
- Modified `delete-permission.tool.ts` to use `permissionId` instead of `key` for better clarity.
- Changed `update-role.tool.ts` to use the PATCH method for role updates.
- Exported the new tool from `src/tools/roles/index.ts` for modularity.